### PR TITLE
Remove references to deprecated files.

### DIFF
--- a/_normalize.scss
+++ b/_normalize.scss
@@ -36,20 +36,11 @@
 @import "typography/dfn";
 @import "typography/hr";
 @import "typography/mark";
-@import "typography/fix-margin";
 @import "typography/fix-monospace";
 @import "typography/pre";
 @import "typography/q";
 @import "typography/small";
 @import "typography/sub-and-sup";
-
-
-/* =============================================================================
-   Lists
-   ========================================================================== */
-
-@import "lists/fix-margin-and-padding";
-@import "lists/inside-nav";
 
 
 /* =============================================================================
@@ -71,7 +62,6 @@
    Forms
    ========================================================================== */
 
-@import "forms/form";
 @import "forms/fieldset";
 @import "forms/legend";
 @import "forms/fix-font";


### PR DESCRIPTION
Remove references to deprecated files which otherwise will cause `not found or unreadable` error.
