### PR TITLE
Fix the styling of <dfn> in _dfn.scss

### DIFF
--- a/typography/_dfn.scss
+++ b/typography/_dfn.scss
@@ -1,8 +1,7 @@
 /**
- * Address styling not present in IE 8/9.
+ * Address styling not present in Safari 5 and Chrome.
  */
 
-mark {
-    background: #ff0;
-    color: #000;
+dfn {
+    font-style: italic;
 }


### PR DESCRIPTION
The content of the file `typography/_dfn.scss` is exactly a duplicate of the content of the file `typography/_mark.scss`. This pull request restores the styling of `_dfn.scss` according to [normalize.css](https://github.com/necolas/normalize.css).
